### PR TITLE
start of engine layer setup function

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1,5 +1,9 @@
 
 
-void update_and_render(){
+void setup(){
+    // NOTE(Lenny): should run once
+}
 
+void update_and_render(){
+    // NOTE(Lenny): should run once every frame
 }


### PR DESCRIPTION
## What has been done?
```void setup()``` Function is introduced to the code base.

## Usage
The ```void setup()``` function will run once at the beginning of the frame. This is where all setup, such as initializing data, will occur.