### PR TITLE
moved fatal_crt_err, xmalloc, wgl_load into helpers file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SRC = $(wildcard src/*.cpp)
 OBJ = $(SRC:%.cpp=%.o)
 DEP = $(SRC:%.cpp=%.d)
 
-all: libs dirs src/menu.o engine
+all: libs dirs src/menu.o src/helpers.o engine
 
 libs:
 	if not exist lib/stb/stb_image.o \

--- a/src/helpers.cpp
+++ b/src/helpers.cpp
@@ -1,0 +1,68 @@
+#include "helpers.hpp"
+
+/**
+ * fatal_crt_error() - Display message box with CRT error and exit 
+ *
+ * This function is used if a C-Runtime (CRT) function fails with
+ * a unrecoverable error. 
+ */
+void fatal_crt_err()
+{
+	wchar_t buf[1024];
+
+	_wcserror_s(buf, _countof(buf), errno);
+	MessageBoxW(NULL, buf, L"CRT Fatal Error", MB_OK); 
+	ExitProcess(1);
+}
+
+
+/**
+ * xmalloc() - Alloc memory, crash on failure
+ * @size: Size of allocation
+ *
+ * Return: Pointer to allocation 
+ *
+ * Pass to "free" to deallocate.
+ */
+void *xmalloc(size_t size)
+{
+	void *ptr;
+
+	if (size == 0) {
+		size = 1;
+	}
+
+	ptr = (char *) malloc(size);
+	if (!ptr) {
+		fatal_crt_err();
+	}
+
+	return ptr;
+}
+
+/**
+ * wgl_load() - load WGL extension function 
+ * @name: name of function 
+ *
+ * Return: Valid function pointer
+ *
+ * Crashes if function not found
+ */
+PROC wgl_load(const char *name) 
+{
+	PROC ret;
+
+	ret = wglGetProcAddress(name);
+	if (!ret) {
+		wchar_t wname[64];
+		wchar_t text[256];
+
+		MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, 
+				name, -1, wname, _countof(wname)); 
+		_snwprintf(text, _countof(text), 
+				L"Could not get proc: %s", wname);
+		MessageBoxW(NULL, text, L"WGL Error", MB_ICONERROR);
+		ExitProcess(1);
+	}
+	return ret;
+}

--- a/src/helpers.hpp
+++ b/src/helpers.hpp
@@ -1,0 +1,38 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define WIN32_LEAN_AND_MEAN
+#define WIN_32_EXTRA_LEAN
+#include <windows.h>
+#include <windowsx.h>
+
+/**
+ * fatal_crt_error() - Display message box with CRT error and exit 
+ *
+ * This function is used if a C-Runtime (CRT) function fails with
+ * a unrecoverable error. 
+ */
+void fatal_crt_err();
+
+/**
+ * xmalloc() - Alloc memory, crash on failure
+ * @size: Size of allocation
+ *
+ * Return: Pointer to allocation 
+ *
+ * Pass to "free" to deallocate.
+ */
+void *xmalloc(size_t size);
+
+/**
+ * wgl_load() - load WGL extension function 
+ * @name: name of function 
+ *
+ * Return: Valid function pointer
+ *
+ * Crashes if function not found
+ */
+PROC wgl_load(const char *name);
+#define WGL_LOAD(func) func = (typeof(func)) wgl_load(#func)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include <stb_image.h>
 #include <wglext.h>
 
+#include "helpers.hpp"
 #include "menu.hpp"
 
 #define MAX_EDITS 256ULL
@@ -35,8 +36,6 @@
 #define ATLAS_LEN (ATLAS_TILE_LEN * TILE_LEN) 
 #define ATLAS_STRIDE (ATLAS_TILE_LEN * TILE_STRIDE) 
 #define SIZEOF_ATLAS (ATLAS_STRIDE * ATLAS_LEN) 
-
-#define WGL_LOAD(func) func = (typeof(func)) wgl_load(#func)
 
 enum edit_type {
 	EDIT_NONE,
@@ -429,45 +428,6 @@ static void process_cmds(int id)
 }
 
 /**
- * fatal_crt_error() - Display message box with CRT error and exit 
- *
- * This function is used if a C-Runtime (CRT) function fails with
- * a unrecoverable error. 
- */
-static void fatal_crt_err(void)
-{
-	wchar_t buf[1024];
-
-	_wcserror_s(buf, _countof(buf), errno);
-	MessageBoxW(g_wnd, buf, L"CRT Fatal Error", MB_OK); 
-	ExitProcess(1);
-}
-
-/**
- * xmalloc() - Alloc memory, crash on failure
- * @size: Size of allocation
- *
- * Return: Pointer to allocation 
- *
- * Pass to "free" to deallocate.
- */
-static void *xmalloc(size_t size)
-{
-	void *ptr;
-
-	if (size == 0) {
-		size = 1;
-	}
-
-	ptr = (char *) malloc(size);
-	if (!ptr) {
-		fatal_crt_err();
-	}
-
-	return ptr;
-}
-
-/**
  * push_place_tile() - Adds tile edit to edit buffer 
  * @x: x position of tile
  * @y: y position of tile
@@ -624,33 +584,6 @@ static void create_main_window(void)
 	g_menu = GetMenu(g_wnd);
 	g_acc = LoadAcceleratorsW(g_ins, MAKEINTRESOURCEW(ID_ACCELERATOR));
 
-}
-
-/**
- * wgl_load() - load WGL extension function 
- * @name: name of function 
- *
- * Return: Valid function pointer
- *
- * Crashes if function not found
- */
-static PROC wgl_load(const char *name) 
-{
-	PROC ret;
-
-	ret = wglGetProcAddress(name);
-	if (!ret) {
-		wchar_t wname[64];
-		wchar_t text[256];
-
-		MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, 
-				name, -1, wname, _countof(wname)); 
-		_snwprintf(text, _countof(text), 
-				L"Could not get proc: %s", wname);
-		MessageBoxW(NULL, text, L"WGL Error", MB_ICONERROR);
-		ExitProcess(1);
-	}
-	return ret;
 }
 
 /**


### PR DESCRIPTION
Moved three functions out of main into a helpers file to prepare main to be restructured into editor-specific, platform-specific, etc code. Not sure if this helps.